### PR TITLE
fix : Prisma Client를 위한 output 경로를 명시적으로 지정.

### DIFF
--- a/prisma/game/schema.prisma
+++ b/prisma/game/schema.prisma
@@ -6,6 +6,7 @@
 
 generator client {
   provider = "prisma-client-js"
+  output = "./generated/gameDataClient"
 }
 
 datasource db {

--- a/prisma/user/schema.prisma
+++ b/prisma/user/schema.prisma
@@ -6,6 +6,7 @@
 
 generator client {
   provider = "prisma-client-js"
+  output = "./generated/userDataClient"
 }
 
 datasource db {


### PR DESCRIPTION
> Issue: JavaScript 코드에서 game db에만 접근이 가능하고 user db에는 접근이 불가

Prisma Client를 위한 output 경로를 명시적으로 지정해주고 다시 각 폴더별로 npx prisma generate를 실행시켜준 뒤에 prisma client를 기존에 사용하던 방식인
```javascript
// src/utils/prisma/index.js
import { PrismaClient } from '@prisma/client';
export const prisma = new PrismaClient();
```
가 아닌 아래의 방식으로 각각 별개의 클라이언트를 통해 각각의 PrismaClient를 통해 접근해야 동작했음.
```javascript
// src/utils/prisma/index.js
import { PrismaClient as GameDataClient } from '../../../prisma/game/generated/gameDataClient/index.js';
import { PrismaClient as UserDataClient } from '../../../prisma/user/generated/userDataClient/index.js';

export const gameDataClient = new GameDataClient(); // game db
export const userDataClient = new UserDataClient(); // user db
```

사용 예시
```javascript
import { userDataClient } from '../utils/prisma/index.js';

export const loadUserData = async (userId) => {
  const user = await userDataClient.users.findFirst({
    where: {
      userId: userId,
    },
  });

  return user;
};
```